### PR TITLE
PARQUET-223: Update new type builders.

### DIFF
--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -678,19 +678,15 @@ public class TestTypeBuilders {
     GroupType map = new GroupType(OPTIONAL, "myMap", OriginalType.MAP, new GroupType(REPEATED, "map",
         typeList));
 
-    MessageType expected = new MessageType("mapParent", map);
-    GroupType actual =
-        Types.buildMessage()
-            .optionalMap()
-              .groupKey()
-                .optional(INT64).named("first")
-                .optional(DOUBLE).named("second")
-              .optionalGroupValue()
-                .optional(DOUBLE).named("one")
-                .optional(INT32).named("two")
-              .named("myMap")
-            .named("mapParent");
-    Assert.assertEquals(expected, actual);
+    GroupType actual = Types.optionalMap()
+        .groupKey()
+          .optional(INT64).named("first")
+          .optional(DOUBLE).named("second")
+        .optionalGroupValue()
+          .optional(DOUBLE).named("one")
+          .optional(INT32).named("two")
+        .named("myMap");
+    Assert.assertEquals(map, actual);
   }
 
   @Test


### PR DESCRIPTION
A series of minor fixes:
- Rename type variables to be more clear:
  - P => parent type
  - THIS => concrete type for this builder
  - M => map builder
  - MP => map builder's parent type
  - L => list builder
  - LP => list builder's parent type
- Validate all method return types
- Use M mapBuilder in key and value builders
- Use L listBuilder in element builders
- Standardize use of named instead of build
- Update Builder: don't require a parent if named is overridden
- Fix setKeyType and setValueType uses
