### PR TITLE
Generalize tests, make Binary.fromString reused=false

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -197,7 +197,10 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
 
   private static class FromStringBinary extends ByteArrayBackedBinary {
     public FromStringBinary(String value) {
-      super(encodeUTF8(value), true);
+      // reused is false, because we do not
+      // hold on to the underlying bytes,
+      // and nobody else has a handle to them
+      super(encodeUTF8(value), false);
     }
 
     private static byte[] encodeUTF8(String value) {

--- a/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
@@ -18,93 +18,198 @@
  */
 package org.apache.parquet.io.api;
 
-import org.junit.Assert;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.apache.parquet.io.api.TestBinary.BinaryFactory.BinaryAndOriginal;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class TestBinary {
-  @Test
-  public void testSliceForByteArrayBackedBinary() {
-    Binary binary = Binary.fromConstantByteArray("test-123".getBytes());
-    Assert.assertArrayEquals("123".getBytes(), binary.slice(5, 3).getBytesUnsafe());
+
+  private static final String testString = "test-123";
+  private static final String UTF8 = "UTF-8";
+
+  static interface BinaryFactory {
+    static class BinaryAndOriginal {
+      public Binary binary;
+      public byte[] original;
+
+      public BinaryAndOriginal(Binary binary, byte[] original) {
+        this.binary = binary;
+        this.original = original;
+      }
+    }
+
+    BinaryAndOriginal get(byte[] bytes, boolean reused) throws Exception;
+  }
+
+  private static void mutate(byte[] bytes) {
+    for (int i = 0; i < bytes.length; i++) {
+      bytes[i] = (byte) (bytes[i] + 1);
+    }
+  }
+
+  private static final BinaryFactory BYTE_ARRAY_BACKED_BF = new BinaryFactory() {
+    @Override
+    public BinaryAndOriginal get(byte[] bytes, boolean reused) throws Exception {
+      byte[] orig = Arrays.copyOf(bytes, bytes.length);
+      if (reused) {
+        return new BinaryAndOriginal(Binary.fromReusedByteArray(orig), orig);
+      } else {
+        return new BinaryAndOriginal(Binary.fromConstantByteArray(orig), orig);
+      }
+    }
+  };
+
+  private static final BinaryFactory BYTE_ARRAY_SLICE_BACKED_BF = new BinaryFactory() {
+    @Override
+    public BinaryAndOriginal get(byte[] bytes, boolean reused) throws Exception {
+      byte [] orig = padded(bytes);
+      Binary b;
+      if (reused) {
+        b = Binary.fromReusedByteArray(orig, 5, bytes.length);
+      } else {
+        b = Binary.fromConstantByteArray(orig, 5, bytes.length);
+      }
+      assertArrayEquals(bytes, b.getBytes());
+      return new BinaryAndOriginal(b, orig);
+    }
+  };
+
+  private static final BinaryFactory BUFFER_BF = new BinaryFactory() {
+    @Override
+    public BinaryAndOriginal get(byte[] bytes, boolean reused) throws Exception {
+      byte [] orig = padded(bytes);
+      ByteBuffer buff = ByteBuffer.wrap(orig, 5, bytes.length);
+      Binary b;
+
+      if (reused) {
+        b = Binary.fromReusedByteBuffer(buff);
+      } else {
+        b = Binary.fromConstantByteBuffer(buff);
+      }
+
+      buff.mark();
+      assertArrayEquals(bytes, b.getBytes());
+      buff.reset();
+      return new BinaryAndOriginal(b, orig);
+    }
+  };
+
+  private static final BinaryFactory STRING_BF = new BinaryFactory() {
+    @Override
+    public BinaryAndOriginal get(byte[] bytes, boolean reused) throws Exception {
+      Binary b = Binary.fromString(new String(bytes, UTF8));
+      return new BinaryAndOriginal(b, b.getBytesUnsafe()); // only way to get underlying bytes for testing
+    }
+  };
+
+  private static byte[] padded(byte[] bytes) {
+    byte[] padded = new byte[bytes.length + 10];
+
+    for (int i = 0; i < 5; i++) {
+      padded[i] = (byte) i;
+    }
+
+    System.arraycopy(bytes, 0, padded, 5, bytes.length);
+
+    for (int i = 0; i < 5; i++) {
+      padded[i + 5 + bytes.length] = (byte) i;
+    }
+
+    return padded;
   }
 
   @Test
-  public void testSliceForByteArraySliceBackedBinary() {
-    Binary binary = Binary.fromConstantByteArray("test-slice-123".getBytes(), 5, 9);
-    Assert.assertArrayEquals("123".getBytes(), binary.slice(6, 3).getBytesUnsafe());
+  public void testByteArrayBackedBinary() throws Exception {
+    testBinary(BYTE_ARRAY_BACKED_BF, true);
+    testBinary(BYTE_ARRAY_BACKED_BF, false);
   }
 
   @Test
-  public void testSliceForByteBufferBackedBinary() {
-    Binary binary = Binary.fromConstantByteBuffer(ByteBuffer.wrap("test-123".getBytes()));
-    Assert.assertArrayEquals("123".getBytes(), binary.slice(5, 3).getBytesUnsafe());
+  public void testByteArraySliceBackedBinary() throws Exception {
+    testBinary(BYTE_ARRAY_SLICE_BACKED_BF, true);
+    testBinary(BYTE_ARRAY_SLICE_BACKED_BF, false);
   }
 
   @Test
-  public void testCopyForConstantByteArrayBackedBinary() {
-    byte[] bytes = "test-123".getBytes();
-    Binary binary = Binary.fromConstantByteArray(bytes);
-    Assert.assertArrayEquals("test-123".getBytes(), binary.copy().getBytesUnsafe());
-
-    final Binary copy = binary.copy();
-    bytes[4] = '.';
-    Assert.assertArrayEquals("test.123".getBytes(), copy.getBytesUnsafe());
+  public void testByteBufferBackedBinary() throws Exception {
+    testBinary(BUFFER_BF, true);
+    testBinary(BUFFER_BF, false);
   }
 
   @Test
-  public void testCopyForReusedByteArrayBackedBinary() {
-    byte[] bytes = "test-123".getBytes();
-    Binary binary = Binary.fromReusedByteArray(bytes);
-    Assert.assertArrayEquals("test-123".getBytes(), binary.copy().getBytesUnsafe());
-
-    final Binary copy = binary.copy();
-    bytes[4] = '.';
-    Assert.assertArrayEquals("test-123".getBytes(), copy.getBytesUnsafe());
+  public void testFromStringBinary() throws Exception {
+    testBinary(STRING_BF, false);
   }
 
-  @Test
-  public void testCopyForConstantByteArraySliceBackedBinary() {
-    byte[] bytes = "slice-test-123".getBytes();
-    Binary binary = Binary.fromConstantByteArray(bytes, 6, 8);
-    Assert.assertArrayEquals("test-123".getBytes(), binary.copy().getBytesUnsafe());
+  private void testSlice(BinaryFactory bf, boolean reused) throws Exception {
+    BinaryAndOriginal bao = bf.get(testString.getBytes(UTF8), reused);
 
-    final Binary copy = binary.copy();
-    bytes[10] = '.';
-    Assert.assertArrayEquals("test.123".getBytes(), copy.getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.slice(0, testString.length()).getBytesUnsafe());
+    assertArrayEquals("123".getBytes(UTF8), bao.binary.slice(5, 3).getBytesUnsafe());
   }
 
-  @Test
-  public void testCopyForReusedByteArraySliceBackedBinary() {
-    byte[] bytes = "slice-test-123".getBytes();
-    Binary binary = Binary.fromReusedByteArray(bytes, 6, 8);
-    Assert.assertArrayEquals("test-123".getBytes(), binary.copy().getBytesUnsafe());
+  private void testConstantCopy(BinaryFactory bf) throws Exception {
+    BinaryAndOriginal bao = bf.get(testString.getBytes(UTF8), false);
+    assertEquals(false, bao.binary.isBackingBytesReused());
 
-    final Binary copy = binary.copy();
-    bytes[10] = '.';
-    Assert.assertArrayEquals("test-123".getBytes(), copy.getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.getBytes());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.copy().getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.copy().getBytes());
+
+    bao = bf.get(testString.getBytes(UTF8), false);
+    assertEquals(false, bao.binary.isBackingBytesReused());
+
+    Binary copy = bao.binary.copy();
+
+    assertSame(copy, bao.binary);
+
+    mutate(bao.original);
+
+    byte[] expected = testString.getBytes(UTF8);
+    mutate(expected);
+
+    assertArrayEquals(expected, copy.getBytes());
+    assertArrayEquals(expected, copy.getBytesUnsafe());
+    assertArrayEquals(expected, copy.copy().getBytesUnsafe());
+    assertArrayEquals(expected, copy.copy().getBytes());
   }
 
-  @Test
-  public void testCopyForConstantByteBufferBackedBinary() {
-    byte[] bytes = "test-123".getBytes();
-    Binary binary = Binary.fromConstantByteBuffer(ByteBuffer.wrap(bytes));
-    Assert.assertArrayEquals("test-123".getBytes(), binary.copy().getBytesUnsafe());
+  private void testReusedCopy(BinaryFactory bf) throws Exception {
+    BinaryAndOriginal bao = bf.get(testString.getBytes(UTF8), true);
+    assertEquals(true, bao.binary.isBackingBytesReused());
 
-    final Binary copy = binary.copy();
-    bytes[4] = '.'; //ByteBuffer's copy always does a copy, unlike other implementations
-    Assert.assertArrayEquals("test-123".getBytes(), copy.getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.getBytes());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.copy().getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), bao.binary.copy().getBytes());
+
+    bao = bf.get(testString.getBytes(UTF8), true);
+    assertEquals(true, bao.binary.isBackingBytesReused());
+
+    Binary copy = bao.binary.copy();
+    mutate(bao.original);
+
+    assertArrayEquals(testString.getBytes(UTF8), copy.getBytes());
+    assertArrayEquals(testString.getBytes(UTF8), copy.getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), copy.copy().getBytesUnsafe());
+    assertArrayEquals(testString.getBytes(UTF8), copy.copy().getBytes());
   }
 
-  @Test
-  public void testCopyForReusedByteBufferBackedBinary() {
-    byte[] bytes = "test-123".getBytes();
-    Binary binary = Binary.fromReusedByteBuffer(ByteBuffer.wrap(bytes));
-    Assert.assertArrayEquals("test-123".getBytes(), binary.copy().getBytesUnsafe());
+  private void testBinary(BinaryFactory bf, boolean reused) throws Exception {
+    testSlice(bf, reused);
 
-    final Binary copy = binary.copy();
-    bytes[4] = '.';
-    Assert.assertArrayEquals("test-123".getBytes(), copy.getBytesUnsafe());
+    if (reused) {
+      testReusedCopy(bf);
+    } else {
+      testConstantCopy(bf);
+    }
+
   }
 }


### PR DESCRIPTION
Am I right about Binary.fromString ? seems like it fits the case of of Binary.fromConstant right? 
